### PR TITLE
Add Write/Read Self

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -27,7 +27,7 @@ func NewReader(src io.Reader) *Reader {
 }
 
 // Offset returns the number of bytes read through this reader.
-func (r *Reader) Offset() uint {
+func (r *Reader) Offset() int64 {
 	return r.src.Offset()
 }
 
@@ -180,6 +180,13 @@ func (r *Reader) ReadText(v encoding.TextUnmarshaler) error {
 	}
 
 	return v.UnmarshalText(b)
+}
+
+// ReadSelf uses the provider io.ReaderFrom in order to read the data from
+// the source reader.
+func (r *Reader) ReadSelf(v io.ReaderFrom) error {
+	_, err := v.ReadFrom(r)
+	return err
 }
 
 // --------------------------- Strings ---------------------------

--- a/source_test.go
+++ b/source_test.go
@@ -112,3 +112,26 @@ func (w *limitWriter) Write(p []byte) (int, error) {
 
 	return w.buffer.Write(p)
 }
+
+func (w *limitWriter) Close() error {
+	return nil
+}
+
+// --------------------------- Self Reader/Writer ---------------------------
+
+type person struct {
+	Name string
+}
+
+func (p *person) WriteTo(dst io.Writer) (int64, error) {
+	w := NewWriter(dst)
+	err := w.WriteString(p.Name)
+	return w.Offset(), err
+}
+
+func (p *person) ReadFrom(src io.Reader) (int64, error) {
+	r := NewReader(src)
+	name, err := r.ReadString()
+	p.Name = name
+	return r.Offset(), err
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -146,6 +146,18 @@ var Fixtures = map[string]struct {
 		Buffer: []byte{0x14, 0x31, 0x39, 0x37, 0x30, 0x2d, 0x30, 0x31, 0x2d, 0x30, 0x31, 0x54, 0x30, 0x30, 0x3a, 0x30, 0x31, 0x3a, 0x30, 0x30, 0x5a},
 		Value:  time.Unix(60, 0).UTC(),
 	},
+	"person": {
+		Encode: func(w *Writer) error {
+			return w.WriteSelf(&person{Name: "Roman"})
+		},
+		Decode: func(r *Reader) (interface{}, error) {
+			var out person
+			err := r.ReadSelf(&out)
+			return out, err
+		},
+		Buffer: []byte{0x5, 0x52, 0x6f, 0x6d, 0x61, 0x6e},
+		Value:  person{Name: "Roman"},
+	},
 }
 
 func TestWrite(t *testing.T) {
@@ -174,6 +186,12 @@ func TestNewWriter(t *testing.T) {
 	w1 := NewWriter(bytes.NewBuffer(nil))
 	w2 := NewWriter(w1)
 	assert.Equal(t, w1, w2)
+	assert.NoError(t, w1.Close())
+}
+
+func TestWriterClose(t *testing.T) {
+	w := NewWriter(new(limitWriter))
+	assert.NoError(t, w.Close())
 }
 
 // assertWrite asserts a single write operation


### PR DESCRIPTION
This PR adds `WriteSelf(io.WriterTo) error` and a corresponding `ReadSelf(io.ReaderFrom) error` which allows for a more efficient streaming of complex structures that already implement self-marshaling mechanism. 