### PR TITLE
Add flush on writer

### DIFF
--- a/source_test.go
+++ b/source_test.go
@@ -117,6 +117,10 @@ func (w *limitWriter) Close() error {
 	return nil
 }
 
+func (w *limitWriter) Flush() error {
+	return nil
+}
+
 // --------------------------- Self Reader/Writer ---------------------------
 
 type person struct {

--- a/writer.go
+++ b/writer.go
@@ -55,8 +55,19 @@ func (w *Writer) write(p []byte) error {
 	return err
 }
 
+// Flush flushes the writer to the underlying stream and returns its error. If
+// the underlying io.Writer does not have a Flush() error method, it's a no-op.
+func (w *Writer) Flush() error {
+	if flusher, ok := w.out.(interface {
+		Flush() error
+	}); ok {
+		return flusher.Flush()
+	}
+	return nil
+}
+
 // Close closes the writer's underlying stream and return its error. If the
-// underlying stream is not an io.Closer, it is a no-op.
+// underlying io.Writer is not an io.Closer, it's a no-op.
 func (w *Writer) Close() error {
 	if closer, ok := w.out.(io.Closer); ok {
 		return closer.Close()

--- a/writer_test.go
+++ b/writer_test.go
@@ -225,6 +225,11 @@ func TestWriterClose(t *testing.T) {
 	assert.NoError(t, w.Close())
 }
 
+func TestWriterFlush(t *testing.T) {
+	assert.NoError(t, NewWriter(new(limitWriter)).Flush())
+	assert.NoError(t, NewWriter(bytes.NewBuffer(nil)).Flush())
+}
+
 // assertWrite asserts a single write operation
 func assertWrite(t *testing.T, name string, fn func(*Writer) error, expect []byte) {
 	assertWriteN(t, name, fn, expect, 99999)


### PR DESCRIPTION
This adds a new `Flush() error` method on the writer, that can call the corresponding flush method on the underlying stream. This is useful when writing into a stream that buffers, for example a compressor.