### PR TITLE
Add slice read/writes

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -89,6 +89,91 @@ func (r *Reader) ReadUint() (uint, error) {
 	return uint(out), err
 }
 
+// ReadUint8s reads an array of uint8s
+func (r *Reader) ReadUint8s() ([]uint8, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]uint8, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadUint8(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// ReadUint16s reads an array of uint16s
+func (r *Reader) ReadUint16s() ([]uint16, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]uint16, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadUint16(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// ReadUint32s reads an array of uint32s
+func (r *Reader) ReadUint32s() ([]uint32, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]uint32, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadUint32(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// ReadUint64s reads an array of uint64s
+func (r *Reader) ReadUint64s() ([]uint64, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]uint64, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadUint64(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// ReadUints reads an array of uints
+func (r *Reader) ReadUints() ([]uint, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]uint, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadUint(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
 // --------------------------- Signed Integers ---------------------------
 
 // ReadVarint reads a variable-length Int64 from the buffer.
@@ -126,6 +211,91 @@ func (r *Reader) ReadInt() (int, error) {
 	return int(out), err
 }
 
+// ReadInt8s reads an array of int8s
+func (r *Reader) ReadInt8s() ([]int8, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]int8, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadInt8(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// ReadInt16s reads an array of int16s
+func (r *Reader) ReadInt16s() ([]int16, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]int16, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadInt16(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// ReadInt32s reads an array of int32s
+func (r *Reader) ReadInt32s() ([]int32, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]int32, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadInt32(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// ReadInt64s reads an array of int64s
+func (r *Reader) ReadInt64s() ([]int64, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]int64, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadInt64(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// ReadUints reads an array of uints
+func (r *Reader) ReadInts() ([]int, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]int, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadInt(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
 // --------------------------- Floats ---------------------------
 
 // ReadFloat32 reads a float32
@@ -144,6 +314,40 @@ func (r *Reader) ReadFloat64() (out float64, err error) {
 		out = math.Float64frombits(v)
 	}
 	return
+}
+
+// ReadFloat32s reads an array of float32s
+func (r *Reader) ReadFloat32s() ([]float32, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]float32, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadFloat32(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// ReadFloat64s reads an array of float64s
+func (r *Reader) ReadFloat64s() ([]float64, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]float64, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadFloat64(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
 }
 
 // --------------------------- Marshaled Types ---------------------------
@@ -211,6 +415,23 @@ func (r *Reader) ReadBytes() (out []byte, err error) {
 	out = make([]byte, int(size))
 	_, err = io.ReadAtLeast(r.src, out, int(size))
 	return
+}
+
+// ReadStrings reads an array of strings
+func (r *Reader) ReadStrings() ([]string, error) {
+	length, err := r.ReadUvarint()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]string, length)
+	for i := 0; i < int(length); i++ {
+		if out[i], err = r.ReadString(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
 }
 
 // --------------------------- Other Types ---------------------------

--- a/writer.go
+++ b/writer.go
@@ -129,6 +129,41 @@ func (w *Writer) WriteUint64(v uint64) error {
 	return w.write(w.scratch[:8])
 }
 
+// WriteUint8s writes an array of uint8s
+func (w *Writer) WriteUint8s(v []uint8) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteUint8(v[i])
+	})
+}
+
+// WriteUint16s writes an array of uint16s
+func (w *Writer) WriteUint16s(v []uint16) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteUint16(v[i])
+	})
+}
+
+// WriteUint32s writes an array of uint32s
+func (w *Writer) WriteUint32s(v []uint32) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteUint32(v[i])
+	})
+}
+
+// WriteUint64s writes an array of uint64s
+func (w *Writer) WriteUint64s(v []uint64) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteUint64(v[i])
+	})
+}
+
+// WriteUints writes an array of uints
+func (w *Writer) WriteUints(v []uint) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteUint(v[i])
+	})
+}
+
 // --------------------------- Signed Integers ---------------------------
 
 // WriteVarint writes a variable size signed integer
@@ -173,6 +208,41 @@ func (w *Writer) WriteInt64(v int64) error {
 	return w.WriteUint64(uint64(v))
 }
 
+// WriteInt8s writes an array of int8s
+func (w *Writer) WriteInt8s(v []int8) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteInt8(v[i])
+	})
+}
+
+// WriteInt16s writes an array of int16s
+func (w *Writer) WriteInt16s(v []int16) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteInt16(v[i])
+	})
+}
+
+// WriteInt32s writes an array of int32s
+func (w *Writer) WriteInt32s(v []int32) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteInt32(v[i])
+	})
+}
+
+// WriteInt64s writes an array of int64s
+func (w *Writer) WriteInt64s(v []int64) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteInt64(v[i])
+	})
+}
+
+// WriteInts writes an array of ints
+func (w *Writer) WriteInts(v []int) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteInt(v[i])
+	})
+}
+
 // --------------------------- Floats ---------------------------
 
 // WriteFloat32 a 32-bit floating point number
@@ -183,6 +253,20 @@ func (w *Writer) WriteFloat32(v float32) error {
 // WriteFloat64 a 64-bit floating point number
 func (w *Writer) WriteFloat64(v float64) error {
 	return w.WriteUint64(math.Float64bits(v))
+}
+
+// WriteFloat32s writes an array of float32s
+func (w *Writer) WriteFloat32s(v []float32) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteFloat32(v[i])
+	})
+}
+
+// WriteFloat64s writes an array of float64s
+func (w *Writer) WriteFloat64s(v []float64) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteFloat64(v[i])
+	})
 }
 
 // --------------------------- Marshaled Types ---------------------------
@@ -230,6 +314,13 @@ func (w *Writer) WriteBytes(v []byte) error {
 		return err
 	}
 	return w.write(v)
+}
+
+// WriteStrings writes an array of strings
+func (w *Writer) WriteStrings(v []string) error {
+	return w.WriteRange(len(v), func(i int, w *Writer) error {
+		return w.WriteString(v[i])
+	})
 }
 
 // --------------------------- Other Types ---------------------------

--- a/writer_test.go
+++ b/writer_test.go
@@ -181,6 +181,84 @@ var Fixtures = map[string]struct {
 		Buffer: []byte{0x2, 0x5, 0x52, 0x6f, 0x6d, 0x61, 0x6e, 0x9, 0x46, 0x6c, 0x6f, 0x72, 0x69, 0x6d, 0x6f, 0x6e, 0x64},
 		Value:  []person{{Name: "Roman"}, {Name: "Florimond"}},
 	},
+	"float32s": {
+		Encode: func(w *Writer) error { return w.WriteFloat32s([]float32{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadFloat32s() },
+		Buffer: []byte{0x1, 0x0, 0x0, 0x88, 0x41},
+		Value:  []float32{0x11},
+	},
+	"float64s": {
+		Encode: func(w *Writer) error { return w.WriteFloat64s([]float64{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadFloat64s() },
+		Buffer: []byte{0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x31, 0x40},
+		Value:  []float64{0x11},
+	},
+	"uint8s": {
+		Encode: func(w *Writer) error { return w.WriteUint8s([]uint8{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadUint8s() },
+		Buffer: []byte{0x1, 0x11},
+		Value:  []uint8{0x11},
+	},
+	"uint16s": {
+		Encode: func(w *Writer) error { return w.WriteUint16s([]uint16{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadUint16s() },
+		Buffer: []byte{0x1, 0x11, 0x0},
+		Value:  []uint16{0x11},
+	},
+	"uint32s": {
+		Encode: func(w *Writer) error { return w.WriteUint32s([]uint32{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadUint32s() },
+		Buffer: []byte{0x1, 0x11, 0x0, 0x0, 0x0},
+		Value:  []uint32{0x11},
+	},
+	"uint64s": {
+		Encode: func(w *Writer) error { return w.WriteUint64s([]uint64{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadUint64s() },
+		Buffer: []byte{0x1, 0x11, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+		Value:  []uint64{0x11},
+	},
+	"uints": {
+		Encode: func(w *Writer) error { return w.WriteUints([]uint{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadUints() },
+		Buffer: []byte{0x1, 0x11, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+		Value:  []uint{0x11},
+	},
+	"int8s": {
+		Encode: func(w *Writer) error { return w.WriteInt8s([]int8{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadInt8s() },
+		Buffer: []byte{0x1, 0x11},
+		Value:  []int8{0x11},
+	},
+	"int16s": {
+		Encode: func(w *Writer) error { return w.WriteInt16s([]int16{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadInt16s() },
+		Buffer: []byte{0x1, 0x11, 0x0},
+		Value:  []int16{0x11},
+	},
+	"int32s": {
+		Encode: func(w *Writer) error { return w.WriteInt32s([]int32{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadInt32s() },
+		Buffer: []byte{0x1, 0x11, 0x0, 0x0, 0x0},
+		Value:  []int32{0x11},
+	},
+	"int64s": {
+		Encode: func(w *Writer) error { return w.WriteInt64s([]int64{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadInt64s() },
+		Buffer: []byte{0x1, 0x11, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+		Value:  []int64{0x11},
+	},
+	"ints": {
+		Encode: func(w *Writer) error { return w.WriteInts([]int{0x11}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadInts() },
+		Buffer: []byte{0x1, 0x11, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+		Value:  []int{0x11},
+	},
+	"strings": {
+		Encode: func(w *Writer) error { return w.WriteStrings([]string{"hello"}) },
+		Decode: func(r *Reader) (interface{}, error) { return r.ReadStrings() },
+		Buffer: []byte{0x1, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f},
+		Value:  []string{"hello"},
+	},
 }
 
 func TestWrite(t *testing.T) {


### PR DESCRIPTION
This pull request introduces new methods for reading and writing arrays of various data types in the `Reader` and `Writer` classes. It also includes corresponding test cases to ensure the new methods work correctly.

### New Methods for Reading Arrays:
* [`reader.go`](diffhunk://#diff-c34cdbc81a6de518e5a2d06b326bfc4179ff5e6b996927ea9232fc0340a424f2R92-R176): Added methods to read arrays of `uint8`, `uint16`, `uint32`, `uint64`, and `uint` (`ReadUint8s`, `ReadUint16s`, `ReadUint32s`, `ReadUint64s`, `ReadUints`).
* [`reader.go`](diffhunk://#diff-c34cdbc81a6de518e5a2d06b326bfc4179ff5e6b996927ea9232fc0340a424f2R214-R298): Added methods to read arrays of `int8`, `int16`, `int32`, `int64`, and `int` (`ReadInt8s`, `ReadInt16s`, `ReadInt32s`, `ReadInt64s`, `ReadInts`).
* [`reader.go`](diffhunk://#diff-c34cdbc81a6de518e5a2d06b326bfc4179ff5e6b996927ea9232fc0340a424f2R319-R352): Added methods to read arrays of `float32` and `float64` (`ReadFloat32s`, `ReadFloat64s`).
* [`reader.go`](diffhunk://#diff-c34cdbc81a6de518e5a2d06b326bfc4179ff5e6b996927ea9232fc0340a424f2R420-R436): Added method to read arrays of `string` (`ReadStrings`).

### New Methods for Writing Arrays:
* [`writer.go`](diffhunk://#diff-6326c99dc4638d1cf8582c8ab1941867b252a173a640030c64678793f10a3b5cR132-R166): Added methods to write arrays of `uint8`, `uint16`, `uint32`, `uint64`, and `uint` (`WriteUint8s`, `WriteUint16s`, `WriteUint32s`, `WriteUint64s`, `WriteUints`).
* [`writer.go`](diffhunk://#diff-6326c99dc4638d1cf8582c8ab1941867b252a173a640030c64678793f10a3b5cR211-R245): Added methods to write arrays of `int8`, `int16`, `int32`, `int64`, and `int` (`WriteInt8s`, `WriteInt16s`, `WriteInt32s`, `WriteInt64s`, `WriteInts`).
* [`writer.go`](diffhunk://#diff-6326c99dc4638d1cf8582c8ab1941867b252a173a640030c64678793f10a3b5cR258-R271): Added methods to write arrays of `float32` and `float64` (`WriteFloat32s`, `WriteFloat64s`).
* [`writer.go`](diffhunk://#diff-6326c99dc4638d1cf8582c8ab1941867b252a173a640030c64678793f10a3b5cR319-R325): Added method to write arrays of `string` (`WriteStrings`).

### Test Cases:
* [`writer_test.go`](diffhunk://#diff-e3884fce926d52cf2f3be76506edc8052b19d3679807f139239394d9496ac79cR184-R261): Added test cases for the new array read and write methods, including `float32s`, `float64s`, `uint8s`, `uint16s`, `uint32s`, `uint64s`, `uints`, `int8s`, `int16s`, `int32s`, `int64s`, `ints`, and `strings`.